### PR TITLE
adapt for arduino ide 1.8.2

### DIFF
--- a/sds018.ino
+++ b/sds018.ino
@@ -35,8 +35,8 @@ void loop() {
         uint8_t pm10Low   = mPkt[4];
         uint8_t pm10High  = mPkt[5];
   
-        float pm25 = ( ( pm25High * 256 ) + pm25Low ) / 10;
-        float pm10 = ( ( pm10High * 256 ) + pm10Low ) / 10;
+        float pm25 = ( ( pm25High * 256.0 ) + pm25Low ) / 10.0;
+        float pm10 = ( ( pm10High * 256.0 ) + pm10Low ) / 10.0;
         
         Serial.print( "PM2.5: " );
         Serial.print( pm25 );


### PR DESCRIPTION
in my context (Arduino IDE 1.8.2, Mac, Adafruit Feather 32u4 with Lora) the C-Compiler is doing late type conversion from int to float when combining the lower and the higher byte. To fix this I put '.0' behin 256 and 10 so they start out as floats. This fixes the problem and should also work with other platforms.